### PR TITLE
Encode spaces in urls with %20.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
 			let mut retries = MAX_RETRIES;
 			let res = loop {
 
-				let req = agent.get(info.url.clone());
+				let req = agent.get(info.url.replace(" ", "%20"));
 				let res = tokio::task::spawn_blocking(move || {
 					let mut res = req.call()?;
 					res.body_mut()


### PR DESCRIPTION
Hi, I noticed that some urls have spaces in them and it would fail to download them with `Error: http: invalid uri character`. This PR encode these spaces.